### PR TITLE
ControlPlane defaulting

### DIFF
--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -19,7 +19,8 @@ type APIServer struct {
 	//
 	// If this is left as the empty string, we will attempt to locate a binary,
 	// by checking for the TEST_ASSET_KUBE_APISERVER environment variable, and
-	// the default test assets directory.
+	// the default test assets directory. See the "Binaries" section above (in
+	// doc.go) for details.
 	Path string
 
 	// CertDir is a path to a directory containing whatever certificates the

--- a/integration/control_plane.go
+++ b/integration/control_plane.go
@@ -13,24 +13,18 @@ type ControlPlane struct {
 	Etcd      *Etcd
 }
 
-// NewControlPlane will give you a ControlPlane struct that's properly wired
-// together.
-func NewControlPlane() *ControlPlane {
-	etcd := &Etcd{}
-	apiserver := &APIServer{}
-
-	return &ControlPlane{
-		APIServer: apiserver,
-		Etcd:      etcd,
-	}
-}
-
 // Start will start your control plane processes. To stop them, call Stop().
 func (f *ControlPlane) Start() error {
+	if f.Etcd == nil {
+		f.Etcd = &Etcd{}
+	}
 	if err := f.Etcd.Start(); err != nil {
 		return err
 	}
 
+	if f.APIServer == nil {
+		f.APIServer = &APIServer{}
+	}
 	f.APIServer.EtcdURL = &f.Etcd.processState.URL
 	return f.APIServer.Start()
 }

--- a/integration/control_plane.go
+++ b/integration/control_plane.go
@@ -37,10 +37,17 @@ func (f *ControlPlane) Start() error {
 
 // Stop will stop your control plane processes, and clean up their data.
 func (f *ControlPlane) Stop() error {
-	if err := f.APIServer.Stop(); err != nil {
-		return err
+	if f.APIServer != nil {
+		if err := f.APIServer.Stop(); err != nil {
+			return err
+		}
 	}
-	return f.Etcd.Stop()
+	if f.Etcd != nil {
+		if err := f.Etcd.Stop(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // APIURL returns the URL you should connect to to talk to your API.

--- a/integration/doc.go
+++ b/integration/doc.go
@@ -13,7 +13,7 @@ and Etcd, you can use `./scripts/download-binaries.sh` to download APIServer
 and Etcd binaries for your platform. Then add something like the following to
 your tests:
 
-	cp := integration.NewControlPlane()
+	cp := &integration.ControlPlane{}
 	cp.Start()
 	// test your client against the API listening at cp.APIURL()
 	cp.Stop()
@@ -23,8 +23,8 @@ Components
 Currently the framework provides the following components:
 
 ControlPlane: The ControlPlane wraps Etcd & APIServer (see below) and wires
-them together correctly. A ControlPlane can be new'd up, stopped & started and
-can provide the URL to connect to the API. The ControlPlane is a good entry
+them together correctly. A ControlPlane can be stopped & started and can
+provide the URL to connect to the API. The ControlPlane is a good entry
 point for default setups.
 
 Etcd: Manages an Etcd binary, which can be started, stopped and connected to.
@@ -47,8 +47,12 @@ use when they get started.
 binary.
 For example:
 
-	cp := integration.NewControlPlane()
-	cp.Etcd.Path = "/usr/bin/etcd"
+	myEtcd := &Etcd{
+		Path: "/some/other/etcd",
+	}
+	cp := &integration.ControlPlane{
+		Etcd: myEtcd,
+	}
 	cp.Start()
 
 2. If the Path field on APIServer or Etcd is left unset and an environment

--- a/integration/doc.go
+++ b/integration/doc.go
@@ -1,29 +1,42 @@
 /*
 
-Package integration implements a integration testing framework for kubernetes.
+Package integration implements an integration testing framework for kubernetes.
 
-It provides a kubernetes API you can connect to and test your
-kubernetes client implementations against. The lifecycle of the components
+It provides components for standing up a kubernetes API, against which you can test a
+kubernetes client, or other kubernetes components. The lifecycle of the components
 needed to provide this API is managed by this framework.
+
+Quickstart
+
+If you want to test a kubernetes client against the latest kubernetes APIServer
+and Etcd, you can use `./scripts/download-binaries.sh` to download APIServer
+and Etcd binaries for your platform. Then add something like the following to
+your tests:
+
+	cp := integration.NewControlPlane()
+	cp.Start()
+	// test your client against the API listening at cp.APIURL()
+	cp.Stop()
 
 Components
 
 Currently the framework provides the following components:
 
-ControlPlane: The ControlPlane is wrapping Etcd & APIServer and provides some
-convenience as it creates instances of the components and wires them together
-correctly. A ControlPlane can be new'd up, stopped & started and provide the
-URL to connect to the API.
-The ControlPlane is supposed to be the default entry point for you.
+ControlPlane: The ControlPlane wraps Etcd & APIServer (see below) and wires
+them together correctly. A ControlPlane can be new'd up, stopped & started and
+can provide the URL to connect to the API. The ControlPlane is a good entry
+point for default setups.
 
 Etcd: Manages an Etcd binary, which can be started, stopped and connected to.
-Etcd will listen on a random port for http connections and will create a
-temporary directory for it'd data; unless configured differently.
+By default Etcd will listen on a random port for http connections and will
+create a temporary directory for its data. To configure it differently, see the
+Etcd type documentation below.
 
 APIServer: Manages an Kube-APIServer binary, which can be started, stopped and
-connected to. APIServer will listen on a random port for http connections and
-will create a temporary directory to store the (auto-generated) certificates;
-unless configured differently.
+connected to. By default APIServer will listen on a random port for http
+connections and will create a temporary directory to store the (auto-generated)
+certificates.  To configure it differently, see the APIServer type
+documentation below.
 
 Binaries
 
@@ -31,22 +44,25 @@ Both Etcd and APIServer use the same mechanism to determine which binaries to
 use when they get started.
 
 1. If the component is configured with a `Path` the framework tries to run that
-binary. (Note: To overwrite the `Path` of a component you cannot use the
-ControlPlane, but you need to create, wire and start & stop all the components
-yourself.)
+binary.
+For example:
 
-2. If a environment variable named
-`TEST_ASSET_KUBE_APISERVER` or `TEST_ASSET_ETCD` is set, this value is used as a
-path to the binary for the APIServer or Etcd.
+	cp := integration.NewControlPlane()
+	cp.Etcd.Path = "/usr/bin/etcd"
+	cp.Start()
 
-3. If neither an environment variable is set nor the `Path` is overwritten
-explicitly, the framework tries to use the binaries apiserver or etcd in the
-directory ${FRAMEWORK_DIRECTORY}/assets/bin/ .
+2. If the Path field on APIServer or Etcd is left unset and an environment
+variable named `TEST_ASSET_KUBE_APISERVER` or `TEST_ASSET_ETCD` is set, its
+value is used as a path to the binary for the APIServer or Etcd.
+
+3. If neither the `Path` field, nor the environment variable is set, the
+framework tries to use the binaries `kube-apiserver` or `etcd` in the directory
+`${FRAMEWORK_DIR}/assets/bin/`.
 
 For convenience this framework ships with
-${FRAMEWORK_DIR}/scripts/download-binaries.sh which can be used to download
+`${FRAMEWORK_DIR}/scripts/download-binaries.sh` which can be used to download
 pre-compiled versions of the needed binaries and place them in the default
-location.
+location (`${FRAMEWORK_DIR}/assets/bin/`).
 
 */
 package integration

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -19,8 +19,9 @@ type Etcd struct {
 	// Path is the path to the etcd binary.
 	//
 	// If this is left as the empty string, we will attempt to locate a binary,
-	// by checking for the TEST_ASSET_ETCD environment variable, and
-	// the default test assets directory.
+	// by checking for the TEST_ASSET_ETCD environment variable, and the default
+	// test assets directory. See the "Binaries" section above (in doc.go) for
+	// details.
 	Path string
 
 	// DataDir is a path to a directory in which etcd can store its state.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -43,6 +43,25 @@ var _ = Describe("The Testing Framework", func() {
 
 		By("Ensuring APIServer is not listening anymore")
 		Expect(isAPIServerListening()).To(BeFalse(), "Expected APIServer not to listen anymore")
+
+		By("Not erroring when stopping a stopped ControlPlane")
+		Expect(func() {
+			Expect(controlPlane.Stop()).To(Succeed())
+		}).NotTo(Panic())
+	})
+
+	Context("when Stop() is called", func() {
+		Context("but the control plane is not started yet", func() {
+			It("does not error", func() {
+				cp := &integration.ControlPlane{}
+
+				stoppingTheControlPlane := func() {
+					Expect(cp.Stop()).To(Succeed())
+				}
+
+				Expect(stoppingTheControlPlane).NotTo(Panic())
+			})
+		})
 	})
 
 	Measure("It should be fast to bring up and tear down the control plane", func(b Benchmarker) {

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -112,6 +112,13 @@ func (ps *ProcessState) Stop() error {
 		return nil
 	}
 
+	// gexec's Session methods (Signal, Kill, ...) do not check if the Process is
+	// nil, so we are doing this here for now.
+	// This should probably be fixed in gexec.
+	if ps.Session.Command.Process == nil {
+		return nil
+	}
+
 	detectedStop := ps.Session.Terminate().Exited
 	timedOut := time.After(ps.StopTimeout)
 


### PR DESCRIPTION
We default Etcd & APIServer on Start() if needed.

Based on #8.