### PR TITLE
Update for kubernetes/kubernetes

### DIFF
--- a/integration/internal/apiserver.go
+++ b/integration/internal/apiserver.go
@@ -14,7 +14,7 @@ func MakeAPIServerArgs(ps DefaultedProcessInput, etcdURL *url.URL) ([]string, er
 		"--authorization-mode=Node,RBAC",
 		"--runtime-config=admissionregistration.k8s.io/v1alpha1",
 		"--v=3", "--vmodule=",
-		"--admission-control=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,SecurityContextDeny,DefaultStorageClass,DefaultTolerationSeconds,GenericAdmissionWebhook,ResourceQuota",
+		"--admission-control=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,SecurityContextDeny,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota",
 		"--admission-control-config-file=",
 		"--bind-address=0.0.0.0",
 		"--storage-backend=etcd3",

--- a/integration/internal/integration_tests/doc.go
+++ b/integration/internal/integration_tests/doc.go
@@ -1,0 +1,7 @@
+/*
+Package integrarion_tests is holding the integration tests to run against the
+framework.
+
+This file's only purpose is to make godep happy.
+*/
+package integration_tests


### PR DESCRIPTION
To use this library in kubernetes/kubernetes we need:

- To have a non-test file in internal/integration_tests -- otherwise godep won't vendor it.
- To avoid using the deprecated GenericAdmissionWebhook flag when calling the api server binary