### PR TITLE
Make kubectl.Run return stdout and stderr

### DIFF
--- a/integration/doc.go
+++ b/integration/doc.go
@@ -16,8 +16,8 @@ your tests:
 	cp := &integration.ControlPlane{}
 	cp.Start()
 	kubeCtl := cp.KubeCtl()
-	err := kubeCtl.Run("get", "pods")
-	// You can check on err, kubeCtl.Stdout & kubeCtl.Stderr and build up
+	stdout, stderr, err := kubeCtl.Run("get", "pods")
+	// You can check on err, stdout & stderr and build up
 	// your tests
 	cp.Stop()
 

--- a/integration/internal/integration_tests/integration_test.go
+++ b/integration/internal/integration_tests/integration_test.go
@@ -2,6 +2,7 @@ package integration_tests
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"time"
 
@@ -42,9 +43,12 @@ var _ = Describe("The Testing Framework", func() {
 
 		By("getting a kubectl & run it against the control plane")
 		kubeCtl := controlPlane.KubeCtl()
-		Expect(kubeCtl.Run("get", "pods")).To(Succeed())
-		Expect(kubeCtl.Stdout).To(BeEmpty())
-		Expect(kubeCtl.Stderr).To(ContainSubstring("No resources found."))
+		stdout, stderr, err := kubeCtl.Run("get", "pods")
+		Expect(err).NotTo(HaveOccurred())
+		bytes, err := ioutil.ReadAll(stdout)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes).To(BeEmpty())
+		Expect(stderr).To(ContainSubstring("No resources found."))
 
 		By("Stopping all the control plane processes")
 		err = controlPlane.Stop()

--- a/integration/kubectl_test.go
+++ b/integration/kubectl_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -11,10 +13,12 @@ var _ = Describe("Kubectl", func() {
 	It("runs kubectl", func() {
 		k := &KubeCtl{Path: "bash"}
 		args := []string{"-c", "echo 'something'"}
-
-		Expect(k.Run(args...)).To(Succeed())
-		Expect(k.Stdout).To(ContainSubstring("something"))
-		Expect(k.Stderr).To(BeEmpty())
+		stdout, stderr, err := k.Run(args...)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("something"))
+		bytes, err := ioutil.ReadAll(stderr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes).To(BeEmpty())
 	})
 
 	Context("when the command returns a non-zero exit code", func() {
@@ -24,12 +28,12 @@ var _ = Describe("Kubectl", func() {
 				"-c", "echo 'this is StdErr' >&2; echo 'but this is StdOut' >&1; exit 66",
 			}
 
-			err := k.Run(args...)
+			stdout, stderr, err := k.Run(args...)
 
 			Expect(err).To(MatchError(ContainSubstring("exit status 66")))
 
-			Expect(k.Stdout).To(ContainSubstring("but this is StdOut"))
-			Expect(k.Stderr).To(ContainSubstring("this is StdErr"))
+			Expect(stdout).To(ContainSubstring("but this is StdOut"))
+			Expect(stderr).To(ContainSubstring("this is StdErr"))
 		})
 	})
 })


### PR DESCRIPTION
This makes more sense than leaving stdout and stderr as part of the
Kubectl struct, because a single struct may run many commands.