### PR TITLE
Integration: Make process arguments configurable

### DIFF
--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -42,10 +42,10 @@ type APIServer struct {
 	StartTimeout time.Duration
 	StopTimeout  time.Duration
 
-	// Out, Err speficy where Etcd should write its StdOut, StdErr to.
+	// Out, Err specify where APIServer should write its StdOut, StdErr to.
 	//
 	// If not specified, these will be left as `nil` and the output of the
-	// process will be descarded and cannot be inspected. However, leaving either
+	// process will be discarded and cannot be inspected. However, leaving either
 	// of those to `nil` is perfectly fine and will not result in any error.
 	Out io.Writer
 	Err io.Writer

--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"io"
 	"net/url"
 	"time"
 
@@ -41,6 +42,14 @@ type APIServer struct {
 	StartTimeout time.Duration
 	StopTimeout  time.Duration
 
+	// Out, Err speficy where Etcd should write its StdOut, StdErr to.
+	//
+	// If not specified, these will be left as `nil` and the output of the
+	// process will be descarded and cannot be inspected. However, leaving either
+	// of those to `nil` is perfectly fine and will not result in any error.
+	Out io.Writer
+	Err io.Writer
+
 	processState *internal.ProcessState
 }
 
@@ -77,7 +86,7 @@ func (s *APIServer) Start() error {
 		&s.URL, &s.CertDir, &s.Path, &s.StartTimeout, &s.StopTimeout,
 	)
 
-	return s.processState.Start(nil, nil)
+	return s.processState.Start(s.Out, s.Err)
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -73,6 +73,10 @@ func (s *APIServer) Start() error {
 
 	s.processState.StartMessage = internal.GetAPIServerStartMessage(s.processState.URL)
 
+	s.processState.CopyTo(
+		&s.URL, &s.CertDir, &s.Path, &s.StartTimeout, &s.StopTimeout,
+	)
+
 	return s.processState.Start()
 }
 

--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -44,9 +44,7 @@ type APIServer struct {
 
 	// Out, Err specify where APIServer should write its StdOut, StdErr to.
 	//
-	// If not specified, these will be left as `nil` and the output of the
-	// process will be discarded and cannot be inspected. However, leaving either
-	// of those to `nil` is perfectly fine and will not result in any error.
+	// If not specified, the output will be discarded.
 	Out io.Writer
 	Err io.Writer
 

--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -80,9 +80,11 @@ func (s *APIServer) Start() error {
 
 	s.processState.StartMessage = internal.GetAPIServerStartMessage(s.processState.URL)
 
-	s.processState.CopyTo(
-		&s.URL, &s.CertDir, &s.Path, &s.StartTimeout, &s.StopTimeout,
-	)
+	s.URL = &s.processState.URL
+	s.CertDir = s.processState.Dir
+	s.Path = s.processState.Path
+	s.StartTimeout = s.processState.StartTimeout
+	s.StopTimeout = s.processState.StopTimeout
 
 	return s.processState.Start(s.Out, s.Err)
 }

--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -77,7 +77,7 @@ func (s *APIServer) Start() error {
 		&s.URL, &s.CertDir, &s.Path, &s.StartTimeout, &s.StopTimeout,
 	)
 
-	return s.processState.Start()
+	return s.processState.Start(nil, nil)
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/integration/control_plane.go
+++ b/integration/control_plane.go
@@ -26,7 +26,7 @@ func (f *ControlPlane) Start() error {
 	if f.APIServer == nil {
 		f.APIServer = &APIServer{}
 	}
-	f.APIServer.EtcdURL = &f.Etcd.processState.URL
+	f.APIServer.EtcdURL = f.Etcd.URL
 	return f.APIServer.Start()
 }
 
@@ -47,7 +47,7 @@ func (f *ControlPlane) Stop() error {
 
 // APIURL returns the URL you should connect to to talk to your API.
 func (f *ControlPlane) APIURL() *url.URL {
-	return &f.APIServer.processState.URL
+	return f.APIServer.URL
 }
 
 // KubeCtl returns a pre-configured KubeCtl, ready to connect to this

--- a/integration/doc.go
+++ b/integration/doc.go
@@ -76,5 +76,38 @@ For convenience this framework ships with
 pre-compiled versions of the needed binaries and place them in the default
 location (`${FRAMEWORK_DIR}/assets/bin/`).
 
+Arguments for Etcd and APIServer
+
+Those components will start without any configuration. However, if you want our
+need to, you can override certain configuration -- one of which are the
+arguments used when calling the binary.
+
+When you choose to specify your own set of arguments, those won't be appended
+to the default set of arguments, it is your responsibility to provide all the
+arguments needed for the binary to start successfully.
+
+All arguments are interpreted as go templates. Those templates have access to
+all exported fields of the `APIServer`/`Etcd` struct. It does not matter if
+those fields where explicitly set up or if they were defaulted by calling the
+`Start()` method, the template evaluation runs just before the binary is
+executed and right after the defaulting of all the struct's fields has
+happened.
+
+	// All arguments needed for a successful start must be specified
+	etcdArgs := []string{
+		"--listen-peer-urls=http://localhost:0",
+		"--advertise-client-urls={{ .URL.String }}",
+		"--listen-client-urls={{ .URL.String }}",
+		"--data-dir={{ .DataDir }}",
+		// add some custom arguments
+		"--this-is-my-very-important-custom-argument",
+		"--arguments-dont-have-to-be-templates=but they can",
+	}
+
+	etcd := &Etcd{
+		Args:    etcdArgs,
+		DataDir: "/my/special/data/dir",
+	}
+
 */
 package integration

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -39,9 +39,7 @@ type Etcd struct {
 
 	// Out, Err specify where Etcd should write its StdOut, StdErr to.
 	//
-	// If not specified, these will be left as `nil` and the output of the
-	// process will be discarded and cannot be inspected. However, leaving either
-	// of those to `nil` is perfectly fine and will not result in any error.
+	// If not specified, the output will be discarded.
 	Out io.Writer
 	Err io.Writer
 

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -66,7 +66,7 @@ func (e *Etcd) Start() error {
 		&e.URL, &e.DataDir, &e.Path, &e.StartTimeout, &e.StopTimeout,
 	)
 
-	return e.processState.Start()
+	return e.processState.Start(nil, nil)
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"io"
 	"time"
 
 	"net/url"
@@ -36,6 +37,14 @@ type Etcd struct {
 	StartTimeout time.Duration
 	StopTimeout  time.Duration
 
+	// Out, Err speficy where Etcd should write its StdOut, StdErr to.
+	//
+	// If not specified, these will be left as `nil` and the output of the
+	// process will be descarded and cannot be inspected. However, leaving either
+	// of those to `nil` is perfectly fine and will not result in any error.
+	Out io.Writer
+	Err io.Writer
+
 	processState *internal.ProcessState
 }
 
@@ -66,7 +75,7 @@ func (e *Etcd) Start() error {
 		&e.URL, &e.DataDir, &e.Path, &e.StartTimeout, &e.StopTimeout,
 	)
 
-	return e.processState.Start(nil, nil)
+	return e.processState.Start(e.Out, e.Err)
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -62,6 +62,10 @@ func (e *Etcd) Start() error {
 
 	e.processState.StartMessage = internal.GetEtcdStartMessage(e.processState.URL)
 
+	e.processState.CopyTo(
+		&e.URL, &e.DataDir, &e.Path, &e.StartTimeout, &e.StopTimeout,
+	)
+
 	return e.processState.Start()
 }
 

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -69,9 +69,11 @@ func (e *Etcd) Start() error {
 
 	e.processState.StartMessage = internal.GetEtcdStartMessage(e.processState.URL)
 
-	e.processState.CopyTo(
-		&e.URL, &e.DataDir, &e.Path, &e.StartTimeout, &e.StopTimeout,
-	)
+	e.URL = &e.processState.URL
+	e.DataDir = e.processState.Dir
+	e.Path = e.processState.Path
+	e.StartTimeout = e.processState.StartTimeout
+	e.StopTimeout = e.processState.StopTimeout
 
 	return e.processState.Start(e.Out, e.Err)
 }

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -37,10 +37,10 @@ type Etcd struct {
 	StartTimeout time.Duration
 	StopTimeout  time.Duration
 
-	// Out, Err speficy where Etcd should write its StdOut, StdErr to.
+	// Out, Err specify where Etcd should write its StdOut, StdErr to.
 	//
 	// If not specified, these will be left as `nil` and the output of the
-	// process will be descarded and cannot be inspected. However, leaving either
+	// process will be discarded and cannot be inspected. However, leaving either
 	// of those to `nil` is perfectly fine and will not result in any error.
 	Out io.Writer
 	Err io.Writer

--- a/integration/etcd_test.go
+++ b/integration/etcd_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"bytes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -27,5 +29,19 @@ var _ = Describe("Etcd", func() {
 		Expect(etcd.Path).NotTo(BeZero())
 		Expect(etcd.StartTimeout).NotTo(BeZero())
 		Expect(etcd.StopTimeout).NotTo(BeZero())
+	})
+
+	It("can inspect IO", func() {
+		stderr := &bytes.Buffer{}
+		etcd := &Etcd{
+			Err: stderr,
+		}
+
+		Expect(etcd.Start()).To(Succeed())
+		defer func() {
+			Expect(etcd.Stop()).To(Succeed())
+		}()
+
+		Expect(stderr.String()).NotTo(BeEmpty())
 	})
 })

--- a/integration/etcd_test.go
+++ b/integration/etcd_test.go
@@ -1,0 +1,31 @@
+package integration_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kubernetes-sig-testing/frameworks/integration"
+)
+
+var _ = Describe("Etcd", func() {
+	It("sets the properties after defaulting", func() {
+		etcd := &Etcd{}
+
+		Expect(etcd.URL).To(BeZero())
+		Expect(etcd.DataDir).To(BeZero())
+		Expect(etcd.Path).To(BeZero())
+		Expect(etcd.StartTimeout).To(BeZero())
+		Expect(etcd.StopTimeout).To(BeZero())
+
+		Expect(etcd.Start()).To(Succeed())
+		defer func() {
+			Expect(etcd.Stop()).To(Succeed())
+		}()
+
+		Expect(etcd.URL).NotTo(BeZero())
+		Expect(etcd.DataDir).NotTo(BeZero())
+		Expect(etcd.Path).NotTo(BeZero())
+		Expect(etcd.StartTimeout).NotTo(BeZero())
+		Expect(etcd.StopTimeout).NotTo(BeZero())
+	})
+})

--- a/integration/internal/apiserver.go
+++ b/integration/internal/apiserver.go
@@ -1,30 +1,20 @@
 package internal
 
-import (
-	"fmt"
-	"net/url"
-)
+import "net/url"
 
-func MakeAPIServerArgs(ps DefaultedProcessInput, etcdURL *url.URL) ([]string, error) {
-	if etcdURL == nil {
-		return []string{}, fmt.Errorf("must configure Etcd URL")
+var APIServerDefaultArgs = []string{
+	"--etcd-servers={{ .EtcdURL.String }}",
+	"--cert-dir={{ .CertDir }}",
+	"--insecure-port={{ .URL.Port }}",
+	"--insecure-bind-address={{ .URL.Hostname }}",
+}
+
+func DoAPIServerArgDefaulting(args []string) []string {
+	if len(args) != 0 {
+		return args
 	}
 
-	args := []string{
-		"--authorization-mode=Node,RBAC",
-		"--runtime-config=admissionregistration.k8s.io/v1alpha1",
-		"--v=3", "--vmodule=",
-		"--admission-control=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,SecurityContextDeny,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota",
-		"--admission-control-config-file=",
-		"--bind-address=0.0.0.0",
-		"--storage-backend=etcd3",
-		fmt.Sprintf("--etcd-servers=%s", etcdURL.String()),
-		fmt.Sprintf("--cert-dir=%s", ps.Dir),
-		fmt.Sprintf("--insecure-port=%s", ps.URL.Port()),
-		fmt.Sprintf("--insecure-bind-address=%s", ps.URL.Hostname()),
-	}
-
-	return args, nil
+	return APIServerDefaultArgs
 }
 
 func GetAPIServerStartMessage(u url.URL) string {

--- a/integration/internal/apiserver_test.go
+++ b/integration/internal/apiserver_test.go
@@ -4,42 +4,23 @@ import (
 	"net/url"
 
 	. "github.com/kubernetes-sig-testing/frameworks/integration/internal"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Apiserver", func() {
-	It("generates APIServer args", func() {
-		processInput := DefaultedProcessInput{
-			Dir: "/some/dir",
-			URL: url.URL{
-				Scheme: "http",
-				Host:   "some.apiserver.host:1234",
-			},
-		}
-		etcdURL := &url.URL{
-			Scheme: "http",
-			Host:   "some.etcd.server",
-		}
-
-		args, err := MakeAPIServerArgs(processInput, etcdURL)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(len(args)).To(BeNumerically(">", 0))
-		Expect(args).To(ContainElement("--etcd-servers=http://some.etcd.server"))
-		Expect(args).To(ContainElement("--cert-dir=/some/dir"))
-		Expect(args).To(ContainElement("--insecure-port=1234"))
-		Expect(args).To(ContainElement("--insecure-bind-address=some.apiserver.host"))
+	It("defaults Args if they are empty", func() {
+		initialArgs := []string{}
+		defaultedArgs := DoAPIServerArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo(APIServerDefaultArgs))
 	})
 
-	Context("when URL is not configured", func() {
-		It("returns an error", func() {
-			var etcdURL *url.URL
-			processInput := DefaultedProcessInput{}
-
-			_, err := MakeAPIServerArgs(processInput, etcdURL)
-			Expect(err).To(MatchError("must configure Etcd URL"))
-		})
+	It("keeps Args as is if they are not empty", func() {
+		initialArgs := []string{"--one", "--two=2"}
+		defaultedArgs := DoAPIServerArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo([]string{
+			"--one", "--two=2",
+		}))
 	})
 })
 

--- a/integration/internal/arguments.go
+++ b/integration/internal/arguments.go
@@ -5,7 +5,7 @@ import (
 	"html/template"
 )
 
-func TemplateArgs(argTemplates []string, data interface{}) (args []string, err error) {
+func RenderTemplates(argTemplates []string, data interface{}) (args []string, err error) {
 	var t *template.Template
 
 	for _, arg := range argTemplates {

--- a/integration/internal/arguments.go
+++ b/integration/internal/arguments.go
@@ -1,0 +1,28 @@
+package internal
+
+import (
+	"bytes"
+	"html/template"
+)
+
+func TemplateArgs(argTemplates []string, data interface{}) (args []string, err error) {
+	var t *template.Template
+
+	for _, arg := range argTemplates {
+		t, err = template.New(arg).Parse(arg)
+		if err != nil {
+			args = nil
+			return
+		}
+
+		buf := &bytes.Buffer{}
+		err = t.Execute(buf, data)
+		if err != nil {
+			args = nil
+			return
+		}
+		args = append(args, buf.String())
+	}
+
+	return
+}

--- a/integration/internal/arguments_test.go
+++ b/integration/internal/arguments_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Arguments", func() {
 			nil,
 		}
 
-		out, err := TemplateArgs(templates, data)
+		out, err := RenderTemplates(templates, data)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(BeEquivalentTo([]string{
 			"plain URL: https://the.host.name:3456",
@@ -48,7 +48,7 @@ var _ = Describe("Arguments", func() {
 			"",
 		}
 
-		out, err := TemplateArgs(templates, data)
+		out, err := RenderTemplates(templates, data)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(BeEquivalentTo([]string{
 			"a string: this is some random string",
@@ -63,7 +63,7 @@ var _ = Describe("Arguments", func() {
 		}
 		data := struct{ test string }{"ooops private"}
 
-		out, err := TemplateArgs(templates, data)
+		out, err := RenderTemplates(templates, data)
 		Expect(out).To(BeEmpty())
 		Expect(err).To(MatchError(
 			ContainSubstring("is an unexported field of struct"),
@@ -71,10 +71,10 @@ var _ = Describe("Arguments", func() {
 	})
 
 	It("errors when field cannot be found", func() {
-		tmplArgs := []string{"this does {{ .NotExist }}"}
+		templates := []string{"this does {{ .NotExist }}"}
 		data := struct{ Unused string }{"unused"}
 
-		out, err := TemplateArgs(tmplArgs, data)
+		out, err := RenderTemplates(templates, data)
 		Expect(out).To(BeEmpty())
 		Expect(err).To(MatchError(
 			ContainSubstring("can't evaluate field"),

--- a/integration/internal/arguments_test.go
+++ b/integration/internal/arguments_test.go
@@ -1,0 +1,83 @@
+package internal_test
+
+import (
+	"net/url"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kubernetes-sig-testing/frameworks/integration/internal"
+)
+
+var _ = Describe("Arguments", func() {
+	It("templates URLs", func() {
+		templates := []string{
+			"plain URL: {{ .SomeURL }}",
+			"method on URL: {{ .SomeURL.Hostname }}",
+			"empty URL: {{ .EmptyURL }}",
+			"handled empty URL: {{- if .EmptyURL }}{{ .EmptyURL }}{{ end }}",
+		}
+		data := struct {
+			SomeURL  *url.URL
+			EmptyURL *url.URL
+		}{
+			&url.URL{Scheme: "https", Host: "the.host.name:3456"},
+			nil,
+		}
+
+		out, err := TemplateArgs(templates, data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeEquivalentTo([]string{
+			"plain URL: https://the.host.name:3456",
+			"method on URL: the.host.name",
+			"empty URL: &lt;nil&gt;",
+			"handled empty URL:",
+		}))
+	})
+
+	It("templates strings", func() {
+		templates := []string{
+			"a string: {{ .SomeString }}",
+			"empty string: {{- .EmptyString }}",
+		}
+		data := struct {
+			SomeString  string
+			EmptyString string
+		}{
+			"this is some random string",
+			"",
+		}
+
+		out, err := TemplateArgs(templates, data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeEquivalentTo([]string{
+			"a string: this is some random string",
+			"empty string:",
+		}))
+	})
+
+	It("has no access to unexported fields", func() {
+		templates := []string{
+			"this is just a string",
+			"this blows up {{ .test }}",
+		}
+		data := struct{ test string }{"ooops private"}
+
+		out, err := TemplateArgs(templates, data)
+		Expect(out).To(BeEmpty())
+		Expect(err).To(MatchError(
+			ContainSubstring("is an unexported field of struct"),
+		))
+	})
+
+	It("errors when field cannot be found", func() {
+		tmplArgs := []string{"this does {{ .NotExist }}"}
+		data := struct{ Unused string }{"unused"}
+
+		out, err := TemplateArgs(tmplArgs, data)
+		Expect(out).To(BeEmpty())
+		Expect(err).To(MatchError(
+			ContainSubstring("can't evaluate field"),
+		))
+	})
+})

--- a/integration/internal/etcd.go
+++ b/integration/internal/etcd.go
@@ -1,19 +1,20 @@
 package internal
 
-import (
-	"fmt"
-	"net/url"
-)
+import "net/url"
 
-func MakeEtcdArgs(input DefaultedProcessInput) []string {
-	args := []string{
-		"--debug",
-		"--listen-peer-urls=http://localhost:0",
-		fmt.Sprintf("--advertise-client-urls=%s", input.URL.String()),
-		fmt.Sprintf("--listen-client-urls=%s", input.URL.String()),
-		fmt.Sprintf("--data-dir=%s", input.Dir),
+var EtcdDefaultArgs = []string{
+	"--listen-peer-urls=http://localhost:0",
+	"--advertise-client-urls={{ .URL.String }}",
+	"--listen-client-urls={{ .URL.String }}",
+	"--data-dir={{ .DataDir }}",
+}
+
+func DoEtcdArgDefaulting(args []string) []string {
+	if len(args) != 0 {
+		return args
 	}
-	return args
+
+	return EtcdDefaultArgs
 }
 
 func isSecureScheme(scheme string) bool {

--- a/integration/internal/etcd_test.go
+++ b/integration/internal/etcd_test.go
@@ -10,19 +10,18 @@ import (
 )
 
 var _ = Describe("Etcd", func() {
-	It("can create Etcd arguments", func() {
-		input := DefaultedProcessInput{
-			URL: url.URL{
-				Scheme: "http",
-				Host:   "some.etcd.service:5432",
-			},
-			Dir: "/some/data/dir",
-		}
+	It("defaults Args if they are empty", func() {
+		initialArgs := []string{}
+		defaultedArgs := DoEtcdArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo(EtcdDefaultArgs))
+	})
 
-		args := MakeEtcdArgs(input)
-		Expect(args).To(ContainElement("--advertise-client-urls=http://some.etcd.service:5432"))
-		Expect(args).To(ContainElement("--listen-client-urls=http://some.etcd.service:5432"))
-		Expect(args).To(ContainElement("--data-dir=/some/data/dir"))
+	It("keeps Args as is if they are not empty", func() {
+		initialArgs := []string{"--eins", "--zwei=2"}
+		defaultedArgs := DoEtcdArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo([]string{
+			"--eins", "--zwei=2",
+		}))
 	})
 })
 

--- a/integration/internal/integration_tests/etcd_intgration_test.go
+++ b/integration/internal/integration_tests/etcd_intgration_test.go
@@ -1,7 +1,8 @@
-package integration_test
+package integration_tests
 
 import (
 	"bytes"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -43,5 +44,23 @@ var _ = Describe("Etcd", func() {
 		}()
 
 		Expect(stderr.String()).NotTo(BeEmpty())
+	})
+
+	It("can use user specified Args", func() {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		etcd := &Etcd{
+			Args:         []string{"--help"},
+			Out:          stdout,
+			Err:          stderr,
+			StartTimeout: 500 * time.Millisecond,
+		}
+
+		// it will timeout, as we'll never see the "startup message" we are waiting
+		// for on StdErr
+		Expect(etcd.Start()).To(MatchError(ContainSubstring("timeout")))
+
+		Expect(stdout.String()).To(ContainSubstring("member flags"))
+		Expect(stderr.String()).To(ContainSubstring("usage: etcd"))
 	})
 })

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -135,3 +135,18 @@ func (ps *ProcessState) Stop() error {
 
 	return nil
 }
+
+func (ps *ProcessState) CopyTo(
+	url **url.URL,
+	dir *string,
+	path *string,
+	startTimeout *time.Duration,
+	stopTimeout *time.Duration,
+) {
+	copiedURL := ps.URL
+	*url = &copiedURL
+	*dir = ps.Dir
+	*path = ps.Path
+	*startTimeout = ps.StartTimeout
+	*stopTimeout = ps.StopTimeout
+}

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -142,18 +142,3 @@ func (ps *ProcessState) Stop() error {
 
 	return nil
 }
-
-func (ps *ProcessState) CopyTo(
-	url **url.URL,
-	dir *string,
-	path *string,
-	startTimeout *time.Duration,
-	stopTimeout *time.Duration,
-) {
-	copiedURL := ps.URL
-	*url = &copiedURL
-	*dir = ps.Dir
-	*path = ps.Path
-	*startTimeout = ps.StartTimeout
-	*stopTimeout = ps.StopTimeout
-}

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -197,6 +197,42 @@ var _ = Describe("DoDefaulting", func() {
 	})
 })
 
+var _ = Describe("CopyTo method", func() {
+	It("copies process state into external variables", func() {
+		ps := ProcessState{}
+		ps.URL = url.URL{Scheme: "https", Host: "some.host.tld:2233"}
+		ps.Dir = "some dir"
+		ps.Path = "some path"
+		ps.StartTimeout = 123
+		ps.StopTimeout = 456
+
+		destination := struct {
+			URL          *url.URL
+			Dir          string
+			Path         string
+			StartTimeout time.Duration
+			StopTimeout  time.Duration
+		}{}
+
+		ps.CopyTo(
+			&destination.URL, &destination.Dir, &destination.Path,
+			&destination.StartTimeout, &destination.StopTimeout,
+		)
+
+		ps.URL = url.URL{}
+		ps.Dir = ""
+		ps.Path = ""
+		ps.StartTimeout = 0
+		ps.StopTimeout = 0
+
+		Expect(destination.URL.String()).To(Equal("https://some.host.tld:2233"))
+		Expect(destination.Dir).To(Equal("some dir"))
+		Expect(destination.Path).To(Equal("some path"))
+		Expect(destination.StartTimeout).To(BeNumerically("==", 123))
+		Expect(destination.StopTimeout).To(BeNumerically("==", 456))
+	})
+})
+
 var simpleBashScript = []string{
 	"-c",
 	`

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -223,42 +223,6 @@ var _ = Describe("DoDefaulting", func() {
 	})
 })
 
-var _ = Describe("CopyTo method", func() {
-	It("copies process state into external variables", func() {
-		ps := ProcessState{}
-		ps.URL = url.URL{Scheme: "https", Host: "some.host.tld:2233"}
-		ps.Dir = "some dir"
-		ps.Path = "some path"
-		ps.StartTimeout = 123
-		ps.StopTimeout = 456
-
-		destination := struct {
-			URL          *url.URL
-			Dir          string
-			Path         string
-			StartTimeout time.Duration
-			StopTimeout  time.Duration
-		}{}
-
-		ps.CopyTo(
-			&destination.URL, &destination.Dir, &destination.Path,
-			&destination.StartTimeout, &destination.StopTimeout,
-		)
-
-		ps.URL = url.URL{}
-		ps.Dir = ""
-		ps.Path = ""
-		ps.StartTimeout = 0
-		ps.StopTimeout = 0
-
-		Expect(destination.URL.String()).To(Equal("https://some.host.tld:2233"))
-		Expect(destination.Dir).To(Equal("some dir"))
-		Expect(destination.Path).To(Equal("some path"))
-		Expect(destination.StartTimeout).To(BeNumerically("==", 123))
-		Expect(destination.StopTimeout).To(BeNumerically("==", 456))
-	})
-})
-
 var simpleBashScript = []string{
 	"-c",
 	`


### PR DESCRIPTION
- The arguments for the APIServer & Etcd binaries are now configurable
- If they are not set, they will default to a minimal set of arguments
- Arguments will be interpolated as go templates

This should resolve #14.

**Note** that this PR is based on #26 and thus looks a bit bigger then it actually is - also #26 should be reviewed merged before this PR.

closes #14 