### PR TITLE
Integration: Parallel tests

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
+	t.Parallel()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Framework Unit Tests")
 }

--- a/integration/internal/apiserver.go
+++ b/integration/internal/apiserver.go
@@ -7,6 +7,7 @@ var APIServerDefaultArgs = []string{
 	"--cert-dir={{ .CertDir }}",
 	"--insecure-port={{ .URL.Port }}",
 	"--insecure-bind-address={{ .URL.Hostname }}",
+	"--secure-port=0",
 }
 
 func DoAPIServerArgDefaulting(args []string) []string {

--- a/integration/internal/integration_tests/integration_suite_test.go
+++ b/integration/internal/integration_tests/integration_suite_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
+	t.Parallel()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Framework Integration Tests")
 }

--- a/integration/internal/internal_suite_test.go
+++ b/integration/internal/internal_suite_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestInternal(t *testing.T) {
+	t.Parallel()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Internal Suite")
 }

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -3,13 +3,12 @@ package internal
 import (
 	"fmt"
 	"io"
-	"net/url"
-	"os/exec"
-	"time"
-
-	"os"
-
 	"io/ioutil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"time"
 
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
@@ -110,7 +109,7 @@ func (ps *ProcessState) Start(stdout, stderr io.Writer) (err error) {
 		return nil
 	case <-timedOut:
 		ps.Session.Terminate()
-		return fmt.Errorf("timeout waiting for process to start serving")
+		return fmt.Errorf("timeout waiting for process %s to start", path.Base(ps.Path))
 	}
 }
 
@@ -133,7 +132,7 @@ func (ps *ProcessState) Stop() error {
 	case <-detectedStop:
 		break
 	case <-timedOut:
-		return fmt.Errorf("timeout waiting for process to stop")
+		return fmt.Errorf("timeout waiting for process %s to stop", path.Base(ps.Path))
 	}
 
 	if ps.DirNeedsCleaning {

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Stop method", func() {
 			processState.Dir, err = ioutil.TempDir("", "k8s_test_framework_")
 			Expect(err).NotTo(HaveOccurred())
 			processState.DirNeedsCleaning = true
-			processState.StopTimeout = 200 * time.Millisecond
+			processState.StopTimeout = 400 * time.Millisecond
 
 			Expect(processState.Stop()).To(Succeed())
 			Expect(processState.Dir).NotTo(BeAnExistingFile())


### PR DESCRIPTION
- APIServer: disable listening for secure connections on default port. This clashes when anything else (e.g. another APIServer) listens on 6443 already.
- Enable parallel testing by default. This may have caught the problem earlier.