### PR TITLE
Add script to run tests on prow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ go_import_path: github.com/kubernetes-sig-testing/frameworks
 
 before_install:
   - source ./bin/consider-early-travis-exit.sh
-  - go get -u github.com/golang/lint/golint
-  - go get -u golang.org/x/tools/cmd/goimports
-  - go get -u github.com/onsi/ginkgo/ginkgo
+  - ./bin/install-test-dependencies.sh
 
 # Install must be set to prevent default `go get` to run.
 # The dependencies have already been vendored by `dep` so

--- a/bin/install-test-dependencies.sh
+++ b/bin/install-test-dependencies.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+go get -u github.com/golang/lint/golint
+go get -u golang.org/x/tools/cmd/goimports
+go get -u github.com/onsi/ginkgo/ginkgo

--- a/bin/test-on-prow.sh
+++ b/bin/test-on-prow.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+./bin/install-test-dependencies.sh
+./bin/pre-commit.sh


### PR DESCRIPTION
To address issue #16. This adds a script to run tests on Prow.

A PR to https://github.com/kubernetes/test-infra will follow to add the Prow job, which will call this script.